### PR TITLE
Fix do keystone build at runtime

### DIFF
--- a/cms/keystone/app/Dockerfile
+++ b/cms/keystone/app/Dockerfile
@@ -20,4 +20,4 @@ RUN npm ci
 
 ENTRYPOINT [ "npm", "run", "start" ]
 
-LABEL version="0.0.11"
+LABEL version="0.0.12"

--- a/cms/keystone/app/package.json
+++ b/cms/keystone/app/package.json
@@ -6,8 +6,8 @@
   "author": "Jonathan Cowling",
   "scripts": {
     "dev": "nodemon",
-    "build": "webpack && keystone build --entry dist/index.js --out dist/assets",
-    "start": "node --unhandled-rejections=strict dist/main.js",
+    "build": "webpack",
+    "start": "keystone build --entry dist/index.js --out dist/assets && node --unhandled-rejections=strict dist/main.js",
     "debug": "node --inspect-brk=${NODE_INSPECT_PORT} --unhandled-rejections=strict dist/main.js",
     "tsc": "tsc",
     "clean": "rm -r ./dist/"


### PR DESCRIPTION
This prevents the generated assets from having the wrong paths